### PR TITLE
Get rid of the CarDriverPair resource

### DIFF
--- a/global/race_control.gd
+++ b/global/race_control.gd
@@ -14,7 +14,7 @@ func _process(delta):
 	pass
 
 
-func add_to_grid(car: CarDriverPair, pos):
+func add_to_grid(car_path, driver_type, pos):
 	if grid.size() >= MAX_CARS:
 		push_warning("Grid is full, cant add more cars ")
 		return
@@ -25,5 +25,10 @@ func add_to_grid(car: CarDriverPair, pos):
 	
 	if pos > grid.size():
 		grid.resize(pos)
+	
+	var car := {
+	"car_path": car_path,
+	"driver_type": driver_type,
+	}
 	
 	grid[pos-1] = car

--- a/scenes/car_driver_pair.gd
+++ b/scenes/car_driver_pair.gd
@@ -1,5 +1,0 @@
-class_name CarDriverPair
-extends Resource
-
-var car_path := ""
-var driver_type = 0

--- a/scenes/car_preview.gd
+++ b/scenes/car_preview.gd
@@ -10,8 +10,9 @@ func _on_car_button_pressed():
 	for child in $CarSpawner/Marker3D.get_children():
 		child.queue_free()
 		print_debug("Child queued free")
-	var car = CarDriverPair.new()
-	car.car_path = SessionManager.player_car_path
-	car.driver_type = 0
+	var car := {
+	"car_path": SessionManager.player_car_path,
+	"driver_type": 0,
+	}
 	$CarSpawner.add_car(car, 0)
 

--- a/scenes/car_spawner.gd
+++ b/scenes/car_spawner.gd
@@ -24,22 +24,19 @@ func _ready():
 			count += 1
 
 
-func add_car(car_n_driver: CarDriverPair, grid_id):
-	var car_path = car_n_driver.car_path
-	var driver_type = car_n_driver.driver_type
-	
-	if car_path == "":
+func add_car(car_dict, grid_id):
+	if car_dict.car_path == "":
 		push_warning("Car path is empty")
 		return
 	
 #	print_debug("car path = %s" % car_path)
-	var car = load(car_path).instantiate()
-	if driver_type == 1:
+	var car = load(car_dict.car_path).instantiate()
+	if car_dict.driver_type == DRIVER_TYPE.PLAYER:
 		for child in car.get_children():
 			if child is BaseCar:
 				child.add_child(load("res://scenes/drivers/player_driver.tscn").instantiate())
 				var driver = PlayerDriver.new()
 				child.set_driver(driver)
-#				
+				
 	grid[grid_id].add_child(car)
 	

--- a/scenes/gui/menus/car_button.gd
+++ b/scenes/gui/menus/car_button.gd
@@ -4,13 +4,12 @@ extends Button
 @export var is_player := true
 
 func _on_car_button_pressed():
-	var car := CarDriverPair.new()
-	car.car_path = car_path
+#	car.car_path = car_path
+	var driver_type := 0
 	if is_player:
 		SessionManager.player_car_path = car_path
-		car.driver_type = 1
+		driver_type = 1
 	
-	# TODO Add cars with their positions somehow
-	RaceControl.add_to_grid(car, 1)
+	RaceControl.add_to_grid(car_path, driver_type, 1)
 	
 


### PR DESCRIPTION
CarDriverPair resource is no longer required since car has instance of Driver subclass (Right now only PlayerDriver) as a member variable. 