### PR TITLE
Implement gamepad steering

### DIFF
--- a/global/input_manager.gd
+++ b/global/input_manager.gd
@@ -109,12 +109,12 @@ func update_input_devices():
 	print_debug(steering_device_sec)
 
 
-func get_steering_input():
-	var steer_left = max(Input.get_action_strength("steer_left"), 
+func get_steering_input() -> float:
+	var steer_left := maxf(Input.get_action_strength("steer_left"), 
 						Input.get_action_strength("steer_left_secondary"))
-	var steer_right = max(Input.get_action_strength("steer_right"), 
+	var steer_right := maxf(Input.get_action_strength("steer_right"), 
 						Input.get_action_strength("steer_right_secondary"))
-	var steering_input = steer_left - steer_right
+	var steering_input := steer_left - steer_right
 	return steering_input
 
 

--- a/resources/configs/options_config.gd
+++ b/resources/configs/options_config.gd
@@ -28,6 +28,7 @@ extends Resource
 "fullscreen" : false,
 "vsync" : true,
 "steering_interpolation" : true,
+"gamepad_steering" : 1.0,
 "master_audio_vol" : 0.5,
 "shadows" : true,
 "ffb_enabled" : false,

--- a/resources/gamepad_steering_curve.tres
+++ b/resources/gamepad_steering_curve.tres
@@ -1,0 +1,5 @@
+[gd_resource type="Curve" format=3 uid="uid://cjilg5ymyp0u4"]
+
+[resource]
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(1, 1), 2.6391, 0.0, 0, 0]
+point_count = 2

--- a/scenes/drivers/player_driver.gd
+++ b/scenes/drivers/player_driver.gd
@@ -1,6 +1,8 @@
 class_name PlayerDriver
 extends Driver
 
+const GAMEPAD_STEERING_CURVE = preload("res://resources/gamepad_steering_curve.tres")
+
 var ffb := FFBPlugin.new()
 var has_ffb := false
 var ffb_effect_id := -1
@@ -63,21 +65,20 @@ func _process(delta: float) -> void:
 
 func _physics_process(delta: float) -> void:
 	brake_input = InputManager.get_brake_input()
-	var raw_steering_input = InputManager.get_steering_input()
+	var raw_steering_input := InputManager.get_steering_input()
 	throttle_input = InputManager.get_throttle_input()
 	handbrake_input = InputManager.get_handbrake_input()
 	clutch_input = InputManager.get_clutch_input()
 	
-#	VehicleAPI.car.wheel_bl.tire_wear = car.wheel_bl.tire_wear
-#	VehicleAPI.car.wheel_br.tire_wear = car.wheel_br.tire_wear
-#	VehicleAPI.car.wheel_fl.tire_wear = car.wheel_fl.tire_wear
-#	VehicleAPI.car.wheel_fr.tire_wear = car.wheel_fr.tire_wear
+	var pad_steering: float = GAMEPAD_STEERING_CURVE.sample_baked(abs(raw_steering_input)) * sign(raw_steering_input)
+	
+	var steering := lerpf(raw_steering_input, pad_steering, OptionsManager.get_config_value("gamepad_steering"))
 	
 		##### Steerin with steer speed #####
 	if OptionsManager.get_config_value("steering_interpolation"):
-		steering_input = steer_lerp(raw_steering_input, steering_input, steer_speed, delta)
+		steering_input = steer_lerp(steering, steering_input, steer_speed, delta)
 	else:
-		steering_input = raw_steering_input
+		steering_input = steering
 	
 #	if abs(car.local_vel.z) > 2.0:
 	if OptionsManager.get_config_value("ffb_enabled"):

--- a/scenes/gui/menus/options_tab.gd
+++ b/scenes/gui/menus/options_tab.gd
@@ -70,6 +70,7 @@ func _ready() -> void:
 	$FFB/VBoxContainer/Options/Values/FFBMinForce.value = OptionsManager.get_config_value("ffb_min_force") * 100
 	$FFB/VBoxContainer/Options/Values/FFBFrontForce.value = OptionsManager.get_config_value("ffb_front_force") * 100
 	$FFB/VBoxContainer/Options/Values/FFBRearForce.value = OptionsManager.get_config_value("ffb_rear_force") * 100
+	$GamePlay/VBoxContainer/GamepadSteering/HSlider.value = OptionsManager.get_config_value("gamepad_steering")
 	
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -199,3 +200,7 @@ func _on_ffb_front_force_value_changed(value: float) -> void:
 
 func _on_ffb_rear_force_value_changed(value: float) -> void:
 	OptionsManager.set_config_value("ffb_rear_force", value * 0.01)
+
+
+func _on_steering_linearity_changed(value: float) -> void:
+	OptionsManager.set_config_value("gamepad_steering", value)

--- a/scenes/gui/menus/options_tab.tscn
+++ b/scenes/gui/menus/options_tab.tscn
@@ -36,6 +36,25 @@ text = "Use steering interpolation"
 [node name="CheckButton" type="CheckButton" parent="GamePlay/VBoxContainer/SteeringInterpolation"]
 layout_mode = 2
 
+[node name="GamepadSteering" type="HBoxContainer" parent="GamePlay/VBoxContainer"]
+custom_minimum_size = Vector2(0, 40)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="GamePlay/VBoxContainer/GamepadSteering"]
+layout_mode = 2
+text = "Steering linearity:	    Linear"
+
+[node name="HSlider" type="HSlider" parent="GamePlay/VBoxContainer/GamepadSteering"]
+custom_minimum_size = Vector2(100, 40)
+layout_mode = 2
+max_value = 1.0
+step = 0.05
+value = 1.0
+
+[node name="Label2" type="Label" parent="GamePlay/VBoxContainer/GamepadSteering"]
+layout_mode = 2
+text = "Non linear"
+
 [node name="Graphics" type="TabBar" parent="."]
 visible = false
 layout_mode = 2
@@ -625,6 +644,7 @@ max_value = 150.0
 suffix = "%"
 
 [connection signal="toggled" from="GamePlay/VBoxContainer/SteeringInterpolation/CheckButton" to="." method="_on_steering_interpolation_toggled"]
+[connection signal="value_changed" from="GamePlay/VBoxContainer/GamepadSteering/HSlider" to="." method="_on_steering_linearity_changed"]
 [connection signal="item_selected" from="Graphics/VBoxContainer/AspectRatio/OptionButton" to="." method="_on_aspect_ratio_selected"]
 [connection signal="item_selected" from="Graphics/VBoxContainer/Resolution/OptionButton" to="." method="_on_resolution_selected"]
 [connection signal="toggled" from="Graphics/VBoxContainer/Fullscreen/CheckButton" to="." method="_on_fullscreen_toggled"]


### PR DESCRIPTION
Adds "gamepad_steering" variable in options. 0.0 for linear, 1.0 for a lot less sensitive steering. Very useful with gamepads. Uses a curve similar to the ease-in preset but a bit more aggressive.